### PR TITLE
Fix memory leak caused  FLastHTTPHeaders created twice

### DIFF
--- a/internet/w32internetaccess.pas
+++ b/internet/w32internetaccess.pas
@@ -364,7 +364,6 @@ var proxyStr:string;
     timeout: longint;
 begin
   init;
-  FLastHTTPHeaders:= TStringList.Create;
   if defaultInternetConfiguration.tryDefaultConfig then
     hSession:=InternetOpenA(pchar(defaultInternetConfiguration.userAgent),
                             INTERNET_OPEN_TYPE_PRECONFIG,


### PR DESCRIPTION
```pascal
procedure TForm1.btnParsujClick(Sender: TObject);
begin
  memZtazeno.Append(process('http://www.google.com','/').toString);
end;
```
resulting in:

```pascal
Heap dump by heaptrc unit
16384 memory blocks allocated : 6469156/6503872
16383 memory blocks freed     : 6469064/6503776
1 unfreed memory blocks : 92
True heap size : 458752 (160 used in System startup)
True free heap : 458416
Should be : 458432
Call trace for block $018EA4C0 size 92
  $0058ABCD  TINTERNETACCESS__INIT,  line 1203 of ./internet/internetaccess.pas
  $00606C5B  TW32INTERNETACCESS__CREATE,  line 366 of ./internet/w32internetaccess.pas
  $0058B297  DEFAULTINTERNET,  line 1403 of ./internet/internetaccess.pas
  $0058B1A5  HTTPREQUEST,  line 1380 of ./internet/internetaccess.pas
  $0054CC63  RETRIEVE,  line 164 of ./internet/simpleinternet.pas
  $0054CDC2  PROCESS,  line 193 of ./internet/simpleinternet.pas
  $0042810F  TFORM1__BTNPARSUJCLICK,  line 225 of unit1.pas
  $004F9E78  TCONTROL__CLICK,  line 2813 of ./include/control.inc
```
Thanks for possible merge
   zbyna
